### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -534,13 +534,14 @@ def test_scheduled_backup(repo_id):
                     return f"Repository {repository.id} not found or inactive"
             except Exception as e:
                 logger.error(f"Error in test backup for repository {repository.id}: {e}")
-                return f"Error: {str(e)}"
+                return "An internal error occurred"
     
     try:
         result = test_backup_with_context()
         return jsonify({'success': True, 'message': result})
     except Exception as e:
-        return jsonify({'success': False, 'error': str(e)}), 500
+        logger.error(f"Error in /api/test-backup/{repo_id}: {e}")
+        return jsonify({'success': False, 'error': 'Internal server error'}), 500
 
 @app.route('/api/theme', methods=['POST'])
 @login_required


### PR DESCRIPTION
Potential fix for [https://github.com/GitTimeraider/GithubBackup-docker/security/code-scanning/3](https://github.com/GitTimeraider/GithubBackup-docker/security/code-scanning/3)

To generally fix this type of issue, never expose full exception messages or stack traces to the user. Instead, return a sanitized, generic error message (for example, "An internal error occurred"). You should still log full error details server-side so developers can diagnose the issue.

**Detailed fix for this code:**  
- In the `except Exception as e:` block at line 542, replace `return jsonify({'success': False, 'error': str(e)}), 500` with a generic error message such as `return jsonify({'success': False, 'error': 'Internal server error'}), 500`.  
- No imports are needed, and logging is already set up (and error is logged via `logger.error` in the relevant context).
- Make sure not to leak sensitive details in any other returned result (for example, check if the internal `test_backup_with_context()` could return sensitive details in error strings – as it currently returns `f"Error: {str(e)}"`).

**File/Region to Change:**
- `app.py`, lines 543 (and consider 537).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
