### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -533,8 +533,8 @@ def test_scheduled_backup(repo_id):
                 else:
                     return f"Repository {repository.id} not found or inactive"
             except Exception as e:
-                logger.error(f"Error in test backup for repository {repository.id}: {e}")
-                return f"Error: {str(e)}"
+                logger.error(f"Error in test backup for repository {repository.id}: {e}", exc_info=True)
+                return "An internal error occurred during the backup operation."
     
     try:
         result = test_backup_with_context()


### PR DESCRIPTION
Potential fix for [https://github.com/GitTimeraider/GithubBackup-docker/security/code-scanning/2](https://github.com/GitTimeraider/GithubBackup-docker/security/code-scanning/2)

In general, sensitive exception information should only be logged on the server, not returned to users. To fix this:
- Change the code to log the exception details (including the message and stack trace) using the server's logging facility.
- Only return a generic error message to the user, such as "An internal error occurred during backup".

**Detailed Steps:**
- In `test_backup_with_context`, replace the return statement that exposes `str(e)` to instead return a generic error string.
- Make sure you log the full exception (possibly with stack trace) using Python's `logging` module, so the details are captured for debugging.
- The calling code at line 541 will remain unchanged, resulting in only the generic message being sent in the JSON response.

All required functionality (logging, Flask, etc.) is already imported and available.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
