### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -540,7 +540,8 @@ def test_scheduled_backup(repo_id):
         result = test_backup_with_context()
         return jsonify({'success': True, 'message': result})
     except Exception as e:
-        return jsonify({'success': False, 'error': str(e)}), 500
+        logger.error(f"Error in /api/test-backup endpoint for repository {repo_id}: {e}", exc_info=True)
+        return jsonify({'success': False, 'error': 'An internal error occurred.'}), 500
 
 @app.route('/api/theme', methods=['POST'])
 @login_required


### PR DESCRIPTION
Potential fix for [https://github.com/GitTimeraider/GithubBackup-docker/security/code-scanning/3](https://github.com/GitTimeraider/GithubBackup-docker/security/code-scanning/3)

To fix the problem, we should avoid exposing the raw exception message (`str(e)`) in API responses. Instead, the error should be logged at the server, and the user should be shown a generic message indicating an internal error. This change must be made in the `/api/test-backup/<int:repo_id>` endpoint, specifically in the exception handler in lines 542-543. Necessary changes include: 

- Replace `return jsonify({'success': False, 'error': str(e)}), 500` with a generic message like `"An internal error occurred."`.
- Add logging of the exception (with stack trace) for server-side diagnostics, if not already present.
- If necessary, ensure an appropriate logging facility (likely `logger.error(..., exc_info=True)`) is used.

No additional imports or dependencies are needed, as logging is already configured.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
